### PR TITLE
Unsigned sensors-prometheus-app in Grafana

### DIFF
--- a/examples/observability/docker-compose.yml
+++ b/examples/observability/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     "./grafana/grafana.ini:/etc/grafana/grafana.ini"
     ]
     ports: ["3000:3000"]
+    environment:
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: "sensors-prometheus-app"
     networks: [observability]
 
 networks:


### PR DESCRIPTION
Modifying docker-compose.yml to allow loading unsigned "sensors-prometheus-app" plugin;